### PR TITLE
MOVE-3770 Updating limit to 1 GiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 # Java 21 releases
 
+# 1.0.1
+
+* ZipBomb protection was upped to 1 GiB pr META-INF entry (see [MOVE-3770](https://digdir.atlassian.net/browse/MOVE-3770))
+
 # 1.0.0
 
 * Java 21

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Latest `1.x.y` series is for Java 21+, while the older series based on Java 8 en
 <dependency>
     <groupId>no.difi.commons</groupId>
     <artifactId>commons-asic</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 </dependency>
 ```
 
@@ -81,11 +81,11 @@ Latest `1.x.y` series is for Java 21+, while the older series based on Java 8 en
 ## Important Note about ZipBomb prevention
 Starting with version 1.0.0 we have added simple protection against [ZipBomb](https://github.com/felleslosninger/efm-asic/security/advisories/GHSA-rc4q-523c-3qmm).
 
-This has been implemented with a custom `ByteArrayOutputStream` that limits decoding of files in `META-INF` to 1 MiB (see [MaxSizeProtectedOutputStream](src/main/java/no/difi/asic/zipbomb/MaxSizeProtectedOutputStream.java)).
+This has been implemented with a custom `ByteArrayOutputStream` that limits decoding of files in `META-INF` to 1 GiB (see [MaxSizeProtectedOutputStream](src/main/java/no/difi/asic/zipbomb/MaxSizeProtectedOutputStream.java), was 1 MiB in v 1.0.0).
 
 The only use of `MaxSizeProtectedOutputStream` is in the `handleMetadataEntry()` method in [AbstractAsicReader](src/main/java/no/difi/asic/AbstractAsicReader.java).
 
-To change the 1 MiB limit we can specify a more exact limit in `handleMetadataEntry()` or set another default inside the `MaxSizeProtectedOutputStream` implementation.
+To change the limit we can specify a more exact size in `handleMetadataEntry()` or set another default inside the `MaxSizeProtectedOutputStream` implementation.
 
 ## What does it look like?
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>no.difi.commons</groupId>
     <artifactId>commons-asic</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Associated Signature Container (ASiC)</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>no.difi.commons</groupId>
     <artifactId>commons-asic</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <name>Associated Signature Container (ASiC)</name>
@@ -12,7 +12,7 @@
     <url>https://github.com/difi/asic</url>
 
     <scm>
-        <tag>commons-asic-1.0.0</tag>
+        <tag>commons-asic-1.0.1</tag>
         <url>https://github.com/difi/asic</url>
         <connection>scm:git:https://github.com/difi/asic.git</connection>
         <developerConnection>scm:git:git@github.com:difi/asic.git</developerConnection>

--- a/src/main/java/no/difi/asic/zipbomb/MaxSizeProtectedOutputStream.java
+++ b/src/main/java/no/difi/asic/zipbomb/MaxSizeProtectedOutputStream.java
@@ -11,10 +11,10 @@ public class MaxSizeProtectedOutputStream extends ByteArrayOutputStream {
     private final long MAX_SIZE_DECOMPRESSED;
 
     /**
-     * Default limit is set to 1 MiB
+     * The default limit is set to 1 GiB
      */
     public MaxSizeProtectedOutputStream() {
-        this(1024L * 1024); // defaults to 1 MiB
+        this(1024L * 1024L * 1024L); // defaults to 1 GiB
     }
 
     /**


### PR DESCRIPTION
Oppdatert standard maks størrelse på filer fra 1 MiB til 1 GiB, ref diskusjon i MOVE-3770 og på Slack.
Dokumentasjon er oppdatert og forventer at denne releasen blir 1.0.1