### PR TITLE
Allow support for Java 11+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     </licenses>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>11</java.version>
         <java.encoding>UTF-8</java.encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
The single line change allows for support of Java 11+ (instead of Java 21+)